### PR TITLE
fix export_into_elastic.py when no conf is set

### DIFF
--- a/pypel/export_file_into_elastic.py
+++ b/pypel/export_file_into_elastic.py
@@ -8,13 +8,16 @@ import numpy as np
 
 
 def main():
-    with open("./conf/config.json") as f:
-        config = json.load(f)
-    file_path, indice = get_args()
-    export_file_into_elastic(file_path, indice, config)
+    try:
+        with open("./conf/config.json") as f:
+            config = json.load(f)
+    except FileNotFoundError:
+        config = {}
+    file_path, indice, sep = get_args()
+    export_file_into_elastic(file_path, indice, config, sep)
 
 
-def export_file_into_elastic(file, indice, config):
+def export_file_into_elastic(file, indice, config, sep):
     elastic_ip = config.get("elastic_ip", "127.0.0.1:9200")
     user = config.get("user", "")
     pwd = config.get("pwd", "")
@@ -24,7 +27,7 @@ def export_file_into_elastic(file, indice, config):
     if file.endswith(".xlsx"):
         df = pd.read_excel(file)
     elif file.endswith(".csv"):
-        df = pd.read_csv(file)
+        df = pd.read_csv(file, sep=sep)
     else:
         raise ValueError(f"{file} is not a valid file.")
     df.replace({np.nan: None, pd.NaT: None}, inplace=True)
@@ -53,8 +56,9 @@ def get_args():
     parser = argparse.ArgumentParser(description='')
     parser.add_argument("-f", "--file-path", default=None, type=str, help="")
     parser.add_argument("-i", "--index", default=None, type=str, help="")
+    parser.add_argument("-s", "--separator", default=",", type=str)
     args = parser.parse_args()
-    return args.file_path, args.index
+    return args.file_path, args.index, args.separator
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Prevent the script from crashing if it fails to find a `config.json` file, and add support for a `separator` parameter for csv files

## Motivation and Context
allows to use the script for single lonely files trivially

## How Has This Been Tested?
used to load files on a local machine

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the code style of this project.
