### PR TITLE
fix format_na

### DIFF
--- a/pypel/transformers/Transformer.py
+++ b/pypel/transformers/Transformer.py
@@ -21,7 +21,7 @@ class Transformer:
         self.format_str_columns(df)
         self.format_contents(df)
         self.format_dates(df)
-        self.format_na(df)
+        df = self.format_na(df)
         return df
 
     def format_str_columns(self, df: pd.DataFrame):


### PR DESCRIPTION
Fix format_na

## Description
format_na was coded like an inplace-method. It is no such method, and thus its code had no effect.

## Motivation and Context
format_na is mandatory for elasticsearch uploads

## How Has This Been Tested?
pytest

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
