### PR TITLE
fix - fix merge_referential & reorder arguments

### DIFF
--- a/pypel/transformers/Transformer.py
+++ b/pypel/transformers/Transformer.py
@@ -120,18 +120,13 @@ class Transformer:
                           **kwargs) -> pd.DataFrame:
         """
         Enrich passed dataframe by merging it with a referential, either passed as dataframe
-            or by a path to extract from, and then return it.
+            or by a path to extract from, and then return it. Additional keyword parameters are passed to the Extractor.
 
         :param df: the dataframe to enrich
         :param mergekey: the mergekeys the merge will be executed upon (pandas merge's on parameter)
         :param referential: the referential to merge with. Either a `Dataframe` a string, or `PathLike`
         :param extractor: the extractor to use for extracting the referential
         :param how: the mergetype e.g. `inner`, `outer` etc... equivalent to pandas.merge's `how` parameter.
-        :param converters: cf pandas' read_excel/read_csv's `converters`
-        :param dates: cf pandas' read_excel/read_csv's `parse_dates`
-        :param dates_format: the date format that will be used when reading data
-        :param sheet_name: cf pandas' read_excel's `sheet_name`
-        :param skiprows: cf pandas' read_excel's `skiprows`
         :return: pd.Dataframe: the enriched dataframe
         """
         if isinstance(referential, pd.DataFrame):


### PR DESCRIPTION
Fix Transformer.merge_referential

## Description

## Motivation and Context
method was broken. tests asserting methods works as intended are added in #51 

## How Has This Been Tested?
tested on #51

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
