### PR TITLE
refacto - remove the NullHandler that nullified logs from main

### DIFF
--- a/pypel/main.py
+++ b/pypel/main.py
@@ -8,10 +8,9 @@ import pypel.utils.elk.init_index as init_index
 import copy
 import logging.handlers
 
-# TODO: rewrite logging calls with warnings.warn as recommended in library code
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-logger.addHandler(logging.NullHandler())
 
 
 def process_into_elastic(conf: dict, params: dict, mappings: dict, process: str = None):


### PR DESCRIPTION
## Description
main.py didnt log anything because of a `NullHandler`. Since that script is designed for application usage, one cannot add handlers to the logger, so the solution was to remove the `NullHandler`

## Motivation and Context
Closes #63

## How Has This Been Tested?

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
