### PR TITLE
Refacto make loaders manage es

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,9 @@ omit =
 branch = true
 [report]
 fail_under = 90.0
+exclude_lines =
+    pragma: no cover
+    @overload
 show_missing = true
 [html]
 directory = tests/reports/coverage/

--- a/README.md
+++ b/README.md
@@ -15,19 +15,22 @@ xlrd (only for .xls)
 
 ## PYPEL in a nutshell
  - What does it do ?
-PYPEL (PYthon Pipeline into ELasticsearch) is a customizable ETL (Extract / Transform / Load) in python. It natively extracts csv, xls & xlsx files and uploads them into elasticsearch.
+PYPEL (PYthon Pipeline into ELasticsearch) is a customizable ETL (Extract / Transform / Load) in python. It natively
+extracts csv, xls & xlsx files and uploads them into elasticsearch.
  - What if my usecase slightly differs from that ?
 The Extract/Transform/Load parts are separated, and you can modify each one independantly to fit your usecase.
 
 ## API summary
 All functionalities are available through the pypel.processes.Process class:
 
- - instantiate your Process : `process = pypel.processes.Process()`
- - extract data : `df = process.extract(file_path)`
- - transform data : `df = process.transform(df)`
- - load data : `process.load(df, es_indice, es_instance)`
-     es_indice is the elasticsearch indice you wanna load into, es_instance is an elasticsearch connection : `es = elasticserach.Elasticsearch(ip, ...)`
- - for conveniance, a wrap-up function exists that bundles all 3 operations in one : `process.process(file_path, es_indice, es_instance)`
+- instantiate your extractor : `loader = pypel.loaders.Loader(es_conf, es_indice)`
+where `es_conf` is elasticsearch's connection configuration (cf `conf_template.json`) and `es_indice` is the
+elasticsearch indice in which to load
+- instantiate your Process : `process = pypel.processes.Process(loader=loader)`
+- extract data : `df = process.extract(file_path)`
+- transform data : `df = process.transform(df)`
+- load data : `process.load(df)`
+- for convenience, a wrap-up function exists that bundles all 3 operations in one : `process.process(file_path)`
 
 The Process constructor takes optional Extractor, Transformer & Loader arguments. These must derive from their BaseClass.
 

--- a/conf_template.json
+++ b/conf_template.json
@@ -6,17 +6,22 @@
         "name": "pypel.extractors.Extractor"
       },
       "Transformers": [
-      {
-        "name": "pypel.transformers.Transformer"
-      }],
+        {
+          "name": "pypel.transformers.Transformer"
+        }
+      ],
       "Loader": {
         "name": "pypel.loaders.Loader",
         "backup": false,
         "name_export": null,
         "dont_append_date": false,
-        "path_to_export_folder": null
-      },
-      "indice": "pypel_bulk"
+        "path_to_export_folder": null,
+        "indice": "pypel_bulk",
+        "es_config": {
+          "user": "elastic",
+          "pwd": "changeme"
+        }
+      }
     },
     {
       "name": "ANOTHER_EXAMPLE",
@@ -28,13 +33,21 @@
           "name": "pypel.transformers.Transformer"
         },
         {
-          "name":"pypel.transformers.ColumnStripperTransformer"
+          "name": "pypel.transformers.ColumnStripperTransformer"
         }
       ],
       "Loader": {
-        "name": "pypel.transformers.Loader"
-      },
-      "indice": "pypel_bulk_2"
+        "name": "pypel.transformers.Loader",
+        "indice": "pypel_bulk_2",
+        "es_config": {
+          "user": "elastic",
+          "pwd": "changeme",
+          "cafile": "path_to_cafile",
+          "scheme": "https",
+          "port": "9200",
+          "host": "localhost"
+        }
+      }
     }
   ]
 }

--- a/pypel/ProcessFactory.py
+++ b/pypel/ProcessFactory.py
@@ -41,12 +41,12 @@ class ProcessFactory:
         :param process_config: Configuration of the process' E/T/L classes as a dictionnary
         :return: A Process instance with the E/T/L classes specified in the configuration
         """
-        extractors = self.create_subclasses(process_config.get("Extractor"))
+        extractor = self.create_subclasses(process_config.get("Extractor"))
         transformers = self.create_subclasses(process_config.get("Transformers"))
-        loaders = self.create_subclasses(process_config.get("Loader"))
-        return Process(extractor=extractors,
+        loader = self.create_subclasses(process_config.get("Loader"))
+        return Process(extractor=extractor,
                        transformer=transformers,
-                       loader=loaders)
+                       loader=loader)
 
     def create_subclasses(self, class_config: Union[Dict[str, str], List[Dict[str, str]]]):
         if class_config is None:

--- a/pypel/ProcessFactory.py
+++ b/pypel/ProcessFactory.py
@@ -28,10 +28,15 @@ class ProcessFactory:
         ...              "Loaders": {"name": "pypel.Loader", "backup": True, "path_to_export_folder": "/",
         ...                          "indice": "my_es_indice"
         ...                          "es_config": {"user": "elastic",
-        ...                                        "pwd": "changeme"}}}
-        Will generate a process with the default Extractor, the transformers BaseTransformer AND MinimalTransformer and
-            a loader `Loader` with instance parameters `backup` and `path_to_export_folder` set to `True` and `/`
-            respectively
+        ...                                        "pwd": "changeme",
+        ...                                        "cafile": "path_to_cafile",
+        ...                                        "scheme": "https",
+        ...                                        "port": "9200",
+        ...                                        "host": "localhost"}}}
+        This config would generate a process with the default Extractor, the transformers BaseTransformer
+            AND MinimalTransformer and a loader `Loader` with instance parameters `backup` and `path_to_export_folder`
+            set to `True` and `/` respectively. Loader will try to connect to elasticsearch using parameters from
+            "es_config".
 
         :param process_config: Configuration of the process' E/T/L classes as a dictionnary
         :return: A Process instance with the E/T/L classes specified in the configuration

--- a/pypel/ProcessFactory.py
+++ b/pypel/ProcessFactory.py
@@ -1,15 +1,23 @@
 import importlib
 from pypel.processes import Process
-from pypel.loaders.Loaders import ElasticsearchConfig
-from typing import Optional, Dict, TypedDict, Union, List
-from pypel.main import ProcessConfig
+from typing import Optional, Dict, Union, List, TypedDict
+
+
+class ProcessConfigMandatory(TypedDict):
+    Extractor: Dict[str, str]
+    Transformers: List[Dict[str, str]]
+    Loader: Dict[str, str]
+
+
+class ProcessConfig(ProcessConfigMandatory, total=False):
+    name: str
 
 
 class ProcessFactory:
     def __init__(self, path_to_refs: Optional[str] = None):
         self.path_to_refs = path_to_refs
 
-    def create_process(self, process_config: ProcessConfig, es_instance: Elasticsearch) -> Process:
+    def create_process(self, process_config: ProcessConfig) -> Process:
         """
         Generates a Process matching a configuration passed as parameter.
 
@@ -17,41 +25,40 @@ class ProcessFactory:
         =======
         >>> my_config = {"Extractors": {"name": "pypel.Extractor"},
         ...              "Transformers": [{"name": "pypel.BaseTransformer"}, {"name": "pypel.MinimalTransformer"}],
-        ...              "Loaders": {"name": "pypel.Loader", "backup": True, "path_to_export_folder": "/"}}
+        ...              "Loaders": {"name": "pypel.Loader", "backup": True, "path_to_export_folder": "/",
+        ...                          "indice": "my_es_indice"
+        ...                          "es_config": {"user": "elastic",
+        ...                                        "pwd": "changeme"}}}
         Will generate a process with the default Extractor, the transformers BaseTransformer AND MinimalTransformer and
             a loader `Loader` with instance parameters `backup` and `path_to_export_folder` set to `True` and `/`
             respectively
 
         :param process_config: Configuration of the process' E/T/L classes as a dictionnary
-        :param es_instance: The Elasticsearch instance to passTYPE_CHECKING to Loader at instanciation
         :return: A Process instance with the E/T/L classes specified in the configuration
         """
-        extractors = self.create_subclasses(process_config.get("Extractors"))
+        extractors = self.create_subclasses(process_config.get("Extractor"))
         transformers = self.create_subclasses(process_config.get("Transformers"))
-        loaders = self.create_subclasses(process_config.get("Loaders"), es_instance=es_instance)
+        loaders = self.create_subclasses(process_config.get("Loader"))
         return Process(extractor=extractors,
                        transformer=transformers,
                        loader=loaders)
 
-    def create_subclasses(self, class_config: Union[Dict[str, str], List[Dict[str, str]]],
-                          es_instance: Optional[Elasticsearch] = None):
+    def create_subclasses(self, class_config: Union[Dict[str, str], List[Dict[str, str]]]):
         if class_config is None:
             return None
         if isinstance(class_config, list):
-            return [self.create_single_class(conf, es_instance=es_instance) for conf in class_config]
+            return [self.create_single_class(conf) for conf in class_config]
         else:
-            return self.create_single_class(class_config, es_instance=es_instance)
+            return self.create_single_class(class_config)
 
-    def create_single_class(self, instance_config: Dict[str, str], es_instance: Optional[Elasticsearch] = None):
+    def create_single_class(self, instance_config: Dict[str, str]):
         canonical_class_name = instance_config.pop("name")
         class_name_splitted = canonical_class_name.split('.')
         class_name = class_name_splitted[-1]
         module_name = ".".join(class_name_splitted[:-1])
         mod = importlib.import_module(module_name)
-        klass = getattr(mod, class_name, None)
-        if klass is None:
+        class_ = getattr(mod, class_name, None)
+        if class_ is None:
             raise ValueError(f"{canonical_class_name} not found in module {module_name}")
-        if es_instance:
-            return klass(es_instance, **instance_config)
         else:
-            return klass(**instance_config)
+            return class_(**instance_config)

--- a/pypel/loaders/Loaders.py
+++ b/pypel/loaders/Loaders.py
@@ -100,7 +100,6 @@ class Loader(BaseLoader):
         Successful loads are logged, errors are sent as warnings
 
         :param actions: a list of elasticsearch actions
-            the elasticserach indice in which data is to be loaded
         :return: None
         """
         success, failed, errors = 0, 0, []
@@ -121,7 +120,6 @@ class Loader(BaseLoader):
 
         :param df: pd.DataFrame
             the DataFrame to upload
-            the indice in which to upload
         :return: returns a list of actions (cf Elasticsearch python API documentation)
         """
         logger.info(f"{len(df.index)} rows in the dataframe")

--- a/pypel/loaders/Loaders.py
+++ b/pypel/loaders/Loaders.py
@@ -6,7 +6,7 @@ import datetime as dt
 import os
 import abc
 from pypel._config.config import get_config
-from typing import Union, Optional, List, Any, TypedDict, Literal
+from typing import Union, Optional, List, Any, TypedDict, Literal, overload
 import ssl
 
 
@@ -28,14 +28,10 @@ class ElasticsearchMinimal(ElasticsearchHost):
     pwd: str
 
 
-class ElasticsearchSSL(TypedDict):
+class ElasticsearchSSL(ElasticsearchMinimal):
     cafile: Union[str, bytes, os.PathLike]
     scheme: Literal["https", "ssh"]
     port: str
-
-
-class ElasticsearchConfig(ElasticsearchMinimal, ElasticsearchSSL):
-    """Typed-Dict for type-hinting purposes"""
 
 
 class BaseLoader:
@@ -56,8 +52,17 @@ class Loader(BaseLoader):
     :param name_export:
     :param dont_append_date:
     """
+    @overload
     def __init__(self,
-                 es_conf: ElasticsearchConfig,
+                 es_conf: ElasticsearchMinimal,
+                 indice: str,
+                 path_to_export_folder: Union[None, str, bytes, os.PathLike] = None,
+                 backup: bool = False,
+                 name_export: Optional[str] = None,
+                 dont_append_date: bool = False) -> None: ...
+
+    def __init__(self,
+                 es_conf: ElasticsearchSSL,
                  indice: str,
                  path_to_export_folder: Union[None, str, bytes, os.PathLike] = None,
                  backup: bool = False,

--- a/pypel/main.py
+++ b/pypel/main.py
@@ -2,49 +2,32 @@ import json
 import os
 import pathlib
 import sys
-import elasticsearch
 import argparse
-import ssl
-from pypel.ProcessFactory import ProcessFactory
+from pypel.ProcessFactory import ProcessFactory, ProcessConfig
 # import pypel.utils.elk.clean_index as clean_index
 # import pypel.utils.elk.init_index as init_index
 import logging.handlers
-from typing import List, Dict, TypedDict, Union, Optional
+from typing import List, TypedDict, Union
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.environ.get("PYPEL_LOGS", "INFO"))
-
-
-class ProcessConfigMandatory(TypedDict):
-    Extractor: Dict[str, str]
-    Transformers: Union[Dict[str, str], List[Dict[str, str]]]
-    Loader: Dict[str, str]
-    indice: str
-
-
-class ProcessConfig(ProcessConfigMandatory):
-    name: str
 
 
 class Config(TypedDict):
     Processes: List[ProcessConfig]
 
 
-def select_process_from_config(es_: elasticsearch.Elasticsearch,
-                               processes: Config,
+def select_process_from_config(processes: Config,
                                process: str,
-                               files: Union[pathlib.Path, str],
-                               indice: Optional[str]):
+                               files: Union[pathlib.Path, str]):
     """
     Given a pair of configurations (global & process configuration `conf`and mapping configuration
     `mappings`), load all processes related to `process`, or all of them if `process` is omitted in to the Elasticsearch
     specified in `conf.elastic_ip`
 
-    :param es_: the elasticsearch instance
     :param processes: the configuration file
     :param process: the process to execute
     :param files: file or list of files to load
-    :param indice: the indice to load into
     :return: does not return
     """
     if processes is None:
@@ -57,36 +40,28 @@ def select_process_from_config(es_: elasticsearch.Elasticsearch,
                              "have a single Process") from e_
     if process == "all":
         for proc in processes:
-            process_from_config(es_, proc, files, indice)
+            process_from_config(proc, files)
     else:
         if process in [conf.get("name") for conf in processes]:
-            process_from_config(es_, [conf for conf in processes if conf.get("name") == process][0], files, indice)
+            process_from_config([conf for conf in processes if conf.get("name") == process][0], files)
         else:
             raise ValueError(f"process {process} not found in the configuration file !")
 
 
-def process_from_config(es_: elasticsearch.Elasticsearch, process: ProcessConfig, files: Union[pathlib.Path, str],
-                        indice: Optional[str]):
+def process_from_config(process: ProcessConfig, files: Union[pathlib.Path, str]):
     """
     Instantiate the process from its passed configuration, and execute it on passed file or directory
 
-    :param es_: the elasticsearch instance
     :param process: the configuration of the process to instantiate
     :param files: the file or directory to process (on)
-    :param indice: the elasticsearch index in which to load data
     :return: None
     """
-    if indice:
-        indice_ = indice
-    else:
-        indice_ = process["indice"]
-    processor = ProcessFactory().create_process(process, es_)
+    processor = ProcessFactory().create_process(process)
     if os.path.isdir(files):
         file_paths = [os.path.join(files, f_).__str__() for f_ in os.listdir(files)]
-        bulk_op = {indice_: file_paths}
-        processor.bulk(bulk_op)
+        processor.bulk(file_paths)
     elif os.path.isfile(files):
-        processor.process(files, indice_, es_)
+        processor.process(files)
     else:
         raise FileNotFoundError(f"Could not find file {files}")
 
@@ -103,31 +78,7 @@ def get_args(args_):
     #  parser.add_argument("-m", "--mapping", default="./conf/index_mappings.json", type=pathlib.Path,
     #                    help="path to the elasticsearch indices's mappings")
     parser.add_argument("-p", "--process", default="all", help="specify the process(es) to execute")
-    parser.add_argument("-i", "--indice", default=None, help="specify the indice to load into")
     return parser.parse_args(args_)
-
-
-def get_es_instance(conf):
-    """Instanciates an Elasticsearch connection instance based on connection parameters from the configuration"""
-    _host = (conf.get("user"), conf.get("pwd"))
-    if _host == (None, None):
-        _host = None
-    if "cafile" in conf:
-        _context = ssl.create_default_context(cafile=conf["cafile"])
-        es_instance = elasticsearch.Elasticsearch(
-            conf.get("host", "localhost"),
-            http_auth=_host,
-            use_ssl=True,
-            scheme=conf["scheme"],
-            port=conf["port"],
-            ssl_context=_context,
-        )
-    else:
-        es_instance = elasticsearch.Elasticsearch(
-            conf.get("host", "localhost"),
-            http_auth=_host,
-        )
-    return es_instance
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -140,7 +91,6 @@ if __name__ == "__main__":  # pragma: no cover
             config = json.load(f)
     except FileNotFoundError as e:
         raise ValueError("Cannot find file passed through the -c / --config-file argument") from e
-    es = get_es_instance(config)
     """
     if args.clean:
         path_to_mapping = os.path.join(os.getcwd(), args.mapping)
@@ -154,4 +104,4 @@ if __name__ == "__main__":  # pragma: no cover
         init_index.init_index(mappings, es_index_client)
     """
     logger.debug(config.get("Processes"))
-    select_process_from_config(es, config.get("Processes"), args.process, args.source_path, args.indice)
+    select_process_from_config(config.get("Processes"), args.process, args.source_path)

--- a/pypel/processes/Processes.py
+++ b/pypel/processes/Processes.py
@@ -2,9 +2,8 @@ import os
 from pypel.extractors.Extractors import BaseExtractor, CSVExtractor
 from pypel.transformers.Transformers import Transformer, BaseTransformer
 from pypel.loaders.Loaders import Loader, BaseLoader
-from elasticsearch import Elasticsearch
 import warnings
-from typing import Dict, List, Union, Optional
+from typing import List, Union, Optional
 from pandas import DataFrame
 
 
@@ -15,14 +14,13 @@ class Process:
     Parameters
     ----------
     :param extractor: Optional[pypel.extractors.Extractor]
-        instance or class to use for extracting data. MUST be derived from pypel.Extractor
+        Extractor instance to use for extracting data. MUST be derived from pypel.extractors.BaseExtractor
     :param transformer: Union[pypel.BaseTransformer, type, List[pypel.transformers.BaseTransformers], None]
         instance, class or list of instances to use for transforming data.
         MUST be derived from pypel.Transformer, for lists, all elements of the list must inherit from pypel.Transformer.
         if list-like, will be for-in looped on, so mind the order.
-
     :param loader: Union[pypel.loaders.BaseLoader, type, None]
-        class to use for loading data. MUST be derived from pypel.Loader
+        Loader instance or class to use for loading data. MUST be derived from pypel.loaders.BaseLoader
 
     Examples
     --------
@@ -67,7 +65,7 @@ class Process:
             raise ValueError("Bad transformer") from e
         try:
             try:
-                assert isinstance(self.loader(None), BaseLoader) # noqa
+                assert issubclass(self.loader, BaseLoader)
                 self.__loader_is_instanced = False
             except TypeError:
                 assert isinstance(self.loader, BaseLoader)
@@ -75,20 +73,15 @@ class Process:
         except AssertionError as e:
             raise ValueError("Bad loader argument") from e
 
-    def process(self, file_path: Union[str, bytes, os.PathLike], es_indice: Optional[str],
-                es_instance: Optional[Elasticsearch] = None) -> None:
+    def process(self, file_path: Union[str, bytes, os.PathLike]) -> None:
         """
-        Conveniance wrapper around Process.extract, Process.transform & Process.load
+        Conveniance wrapper around Process.extract, Process.transform & Process.load. Relies on instanced E/T/L classes.
 
         :param file_path:
             path to the file to be extracted
-        :param es_instance:
-            elasticsearch connection to use for loading
-        :param es_indice:
-            the name of the elasticsearch indice in which data is to be loaded
         :return: None
         """
-        self.load(self.transform(self.extract(file_path)), es_indice, es_instance=es_instance)
+        self.load(self.transform(self.extract(file_path)))
 
     def extract(self, file_path: Union[str, bytes, os.PathLike], **kwargs) -> DataFrame:
         """
@@ -130,17 +123,12 @@ class Process:
         else:
             return self.transformer(*args, **kwargs).transform(dataframe)
 
-    def load(self, df, es_indice: str,
-             es_instance: Optional[Elasticsearch] = None, *args, **kwargs) -> None:
+    def load(self, df, *args, **kwargs) -> None:
         """
         Loads the passed dataframe into the passed elasticsearch instance's indice es_indice.
 
         :param df: pd.Dataframe
             the dataframe to load
-        :param es_indice:
-            the elasticsearch indice in which to load
-        :param es_instance:
-            the elasticsearch instance in which to load
         :param args:
             optional positional parameters for custom loader instanciation
         :param kwargs:
@@ -150,31 +138,28 @@ class Process:
         if self.__loader_is_instanced:
             if len(args) + len(kwargs) > 0:
                 warnings.warn("Instanced loader receiving extra arguments !")
-            self.loader.load(df, es_indice) # noqa
+            self.loader.load(df)
         else:
-            assert isinstance(es_instance, Elasticsearch)
-            self.loader(es_instance, *args, **kwargs).load(df, es_indice)
+            self.loader(*args, **kwargs).load(df)
 
-    def bulk(self, file_indice_dic: Union[Dict[str, str], Dict[str, List[str]]]) -> None:
+    def bulk(self,  file_list: List[str]) -> None:
         """
-        Given a dict of format {file1: indice1, file2: indice2} or {indice1: [file1, file2], indice2: [file3, file4]}
-            extract and transform all files before loading into the corresponding indice.
+        Given a list of files, loads the files into the loader's indice.
             Only works for Process with instanced Extractors, Transformers and Loaders
 
         =======
         Example
-        >>> process = Process(CSVExtractor(), Transformer(), Loader())
-        >>> myconf = {"covid_stats.csv": "covid", "relance.xls": "relance", "obscure_name.xlsx": "id7654"}
+        >>> process = Process(CSVExtractor(), Transformer(), Loader({"user": "", "pwd": ""}, "my_indice"))
+        >>> myconf = ["covid_stats.csv", "relance.xls", "obscure_name.xlsx"]
         >>> process.bulk(myconf)
         Equivalent to
-        >>> for f, i in myconf:
-        ...     process.process(f, i)
+        >>> for i in myconf:
+        ...     process.process(i)
         Example in the second format
-        >>> my_second_conf = {"covid": ["covid_stats_2020.csv", "covid_stats_2021.csv"]}
+        >>> my_second_conf = ["covid_stats_2020.csv", "covid_stats_2021.csv"]
         >>> process.bulk(my_second_conf)
 
-        :param file_indice_dic: the dictionnary of parameters to use for extracting and loading. Must be in the format
-            {file1: indice1}
+        :param file_list: the list of files to be bulked into the loader's indice
         :return: None
         """
         try:
@@ -189,9 +174,5 @@ class Process:
                 else:
                     err = "Loader"
             raise ValueError(f"{err} not instanced")
-        for key, value in file_indice_dic.items():
-            if isinstance(value, list):
-                for file in value:
-                    self.process(file, key)
-            else:
-                self.process(key, value)
+        for file in file_list:
+            self.process(file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,10 +30,11 @@ def df():
     return DataFrame({"0": [0, 1, 2]})
 
 
-class Elasticsearch:
-    pass
+@pytest.fixture
+def es_conf():
+    return {}
 
 
 @pytest.fixture
-def es_instance():
-    return Elasticsearch()
+def es_indice():
+    return "test_indice"

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,61 +1,59 @@
-import elasticsearch
+# noinspection PyPackageRequirements
 import pytest
 import pypel.processes
-import ssl
 import os
-from pypel.main import get_args, select_process_from_config, process_from_config, get_es_instance
+from pypel.main import get_args, select_process_from_config, process_from_config
 
 
 @pytest.fixture
-def process_config():
+def process_config(es_conf, es_indice):
     return {
-        "Extractors": {
+        "Extractor": {
             "name": "pypel.extractors.Extractor"
         },
         "Transformers": [{
             "name": "pypel.transformers.Transformer"
         }],
-        "Loaders": {
+        "Loader": {
             "name": "pypel.loaders.Loader",
-        },
-        "indice": "my_indice"
+            "es_conf": es_conf,
+            "indice": es_indice
+        }
     }
 
 
 @pytest.fixture
-def processes_config():
+def processes_config(es_conf):
     return [{
-                "name": "EXAMPLE",
-                "Extractors": {
-                    "name": "pypel.extractors.Extractor"
-                },
-                "Transformers": [
-                    {
-                        "name": "pypel.transformers.ColumnStripperTransformer"
-                    }
-                ],
-                "Loaders": {
-                    "name": "pypel.loaders.Loader"
-                },
-                "indice": "pypel_bulk"
-            },
+        "name": "EXAMPLE",
+        "Extractor": {
+            "name": "pypel.extractors.Extractor"
+        },
+        "Transformers": [
             {
-                "name": "ANOTHER_EXAMPLE",
-                "Extractors": {
-                    "name": "pypel.extractors.Extractor"
-                },
-                "Transformers": [{
-                    "name": "pypel.transformers.Transformer"
-                }],
-                "Loaders": {
-                    "name": "pypel.loaders.Loader"
-                },
-                "indice": "pypel_bulk_2"
-            }]
-
-
-def mock_ssl_context(cafile):
-    return {"name": cafile}
+                "name": "pypel.transformers.ColumnStripperTransformer"
+            }
+        ],
+        "Loader": {
+            "name": "pypel.loaders.Loader",
+            "indice": "pypel_bulk",
+            "es_conf": es_conf
+        }
+    },
+        {
+            "name": "ANOTHER_EXAMPLE",
+            "Extractor": {
+                "name": "pypel.extractors.Extractor"
+            },
+            "Transformers": [{
+                "name": "pypel.transformers.Transformer"
+            }],
+            "Loader": {
+                "name": "pypel.loaders.Loader",
+                "indice": "pypel_bulk_2",
+                "es_conf": es_conf
+            }
+        }]
 
 
 class TestGetArgs:
@@ -67,12 +65,6 @@ class TestGetArgs:
         key = "process"
         expected = "MyProcess"
         actual = get_args(["-p", "MyProcess", "-f", "/f"]).__getattribute__(key)
-        assert expected == actual
-
-    def test_indice(self):
-        key = "indice"
-        expected = "my_indice"
-        actual = get_args(["-i", "my_indice", "-f", "/f"]).__getattribute__(key)
         assert expected == actual
 
     def test_source_path(self):
@@ -91,8 +83,7 @@ class TestGetArgs:
         expected = {
             "source_path": "/home/user/data.csv",
             "config_file": "./conf/config.json",
-            "process": "all",
-            "indice": None}
+            "process": "all"}
         actual = get_args(["-f", "/home/user/data.csv"])
         for key in actual.__dict__:
             assert actual.__getattribute__(key) == expected[key]
@@ -101,109 +92,65 @@ class TestGetArgs:
         expected = {
             "source_path": "/file",
             "config_file": "/home/user/pypel_conf.json",
-            "process": "MYPROCESS",
-            "indice": "indice"}
-        actual = get_args(["-f", "/file", "-i", "indice", "-c", "/home/user/pypel_conf.json", "-p", "MYPROCESS"])
+            "process": "MYPROCESS"}
+        actual = get_args(["-f", "/file", "-c", "/home/user/pypel_conf.json", "-p", "MYPROCESS"])
         for key in actual.__dict__:
             assert actual.__getattribute__(key) == expected[key]
 
 
-class TestGetESInstance:
-    def test_no_authentication(self, monkeypatch):
-        def assert_es_instanciation_called_with(hosts, http_auth, use_ssl=False, scheme=None, port=8080,
-                                                ssl_context=None):
-            assert hosts == "localhost"
-            assert http_auth is None
-        monkeypatch.setattr(elasticsearch, "Elasticsearch", assert_es_instanciation_called_with)
-        get_es_instance({})
-
-    def test_authentication_no_cafile(self, monkeypatch):
-        def assert_es_instanciation_called_with(hosts, http_auth, use_ssl=False, scheme=None, port=8080,
-                                                ssl_context=None):
-            assert hosts == "localhost"
-            assert http_auth == ("user", "my_pwd")
-
-        monkeypatch.setattr(elasticsearch, "Elasticsearch", assert_es_instanciation_called_with)
-        get_es_instance({"user": "user", "pwd": "my_pwd"})
-
-    def test_cafile(self, monkeypatch):
-        def assert_es_instanciation_called_with(hosts, http_auth, use_ssl=False, scheme=None, port=8080,
-                                                ssl_context=None):
-            assert hosts == "1.12.4.2"
-            assert http_auth == ("elastic", "changeme")
-            assert use_ssl is True
-            assert scheme == "https"
-            assert port == 8080
-            assert ssl_context == {"name": "fake_cafile_content"}
-
-        monkeypatch.setattr(elasticsearch, "Elasticsearch", assert_es_instanciation_called_with)
-        monkeypatch.setattr(ssl, "create_default_context", mock_ssl_context)
-        get_es_instance({"user": "elastic", "pwd": "changeme", "host": "1.12.4.2", "scheme": "https", "port": 8080,
-                         "cafile": "fake_cafile_content"})
-
-
 class TestProcessFromConfig:
-    def test_raises_if_non_existant_file(self, process_config, es_instance):
+    def test_raises_if_non_existant_file(self, process_config):
         with pytest.raises(FileNotFoundError, match="Could not find file /i_do_not_exist"):
-            process_from_config(es_instance, process_config, "/i_do_not_exist", None)
+            process_from_config(process_config, "/i_do_not_exist")
 
-    def test_single_file(self, monkeypatch, process_config, es_instance):
-        def process_assert_called_with(_, file_path, indice, instance):
+    def test_single_file(self, monkeypatch, process_config):
+        def process_assert_called_with(_, file_path):
             assert file_path == "./tests/fake_data/test_init_df.csv"
-            assert indice == "my_indice"
-            assert instance is es_instance
 
         monkeypatch.setattr(pypel.processes.Process, "process", process_assert_called_with)
-        process_from_config(es_instance, process_config, "./tests/fake_data/test_init_df.csv", None)
+        process_from_config(process_config, "./tests/fake_data/test_init_df.csv")
 
-    def test_with_cl_indice(self, monkeypatch, process_config, es_instance):
-        def process_assert_called_with(_, file_path, indice, instance):
+    def test_with_cl_indice(self, monkeypatch, process_config):
+        def process_assert_called_with(_, file_path):  # _ is self here
             assert file_path == "./tests/fake_data/test_init_df.csv"
-            assert indice == "indice"
-            assert instance is es_instance
 
         monkeypatch.setattr(pypel.processes.Process, "process", process_assert_called_with)
-        process_from_config(es_instance, process_config, "./tests/fake_data/test_init_df.csv", "indice")
+        process_from_config(process_config, "./tests/fake_data/test_init_df.csv")
 
-    def test_directory(self, monkeypatch, process_config, es_instance):
-        def bulk_assert_called_with(_, dic):
-            assert dic == {
-                "my_indice": [os.path.join("./tests/fake_data/", file) for file in os.listdir("./tests/fake_data/")]}
+    def test_directory(self, monkeypatch, process_config):
+        def bulk_assert_called_with(_, list_):  # _ is self here
+            assert list_ == [os.path.join("./tests/fake_data/", file) for file in os.listdir("./tests/fake_data/")]
 
         monkeypatch.setattr(pypel.processes.Process, "bulk", bulk_assert_called_with)
-        process_from_config(es_instance, process_config, "./tests/fake_data/", None)
+        process_from_config(process_config, "./tests/fake_data/")
 
 
 class TestSelectProcessFromConfig:
-    def test_raises_if_processes_not_found(self, es_instance):
+    def test_raises_if_processes_not_found(self):
         with pytest.raises(ValueError, match="key 'Processes' not found in the passed config, no idea what to do."):
-            select_process_from_config(es_instance, None, None, None, None)
+            select_process_from_config(None, "", "")
 
-    def test_raises_if_processes_not_a_list(self, es_instance):
+    def test_raises_if_processes_not_a_list(self):
         with pytest.raises(ValueError,
                            match="Processes is not a list, please encapsulate Processes inside a list even if you only "
                                  "have a single Process"):
-            select_process_from_config(es_instance, {}, None, None, None)
+            select_process_from_config({}, "", "")
 
-    def test_raises_if_process_not_in_processes(self, es_instance, processes_config):
+    def test_raises_if_process_not_in_processes(self, processes_config):
         with pytest.raises(ValueError, match="process DOESNOTEXIST not found in the configuration file !"):
-            select_process_from_config(es_instance, processes_config, "DOESNOTEXIST", "/file", None)
+            select_process_from_config(processes_config, "DOESNOTEXIST", "/file")
 
-    def test_single_process(self, es_instance, monkeypatch, processes_config):
-        def process_from_conf_assert_called_with(es, proc, file, indice):
-            assert es == es_instance
+    def test_single_process(self, monkeypatch, processes_config):
+        def process_from_conf_assert_called_with(proc, file):
             assert proc == processes_config[0]
             assert file == "/file"
-            assert indice is None
 
         monkeypatch.setattr(pypel.main, "process_from_config", process_from_conf_assert_called_with)
-        select_process_from_config(es_instance, processes_config, "EXAMPLE", "/file", None)
+        select_process_from_config(processes_config, "EXAMPLE", "/file")
 
-    def test_multiple_processes(self, es_instance, mocker, processes_config):
+    def test_multiple_processes(self, mocker, processes_config):
         mocker.patch('pypel.main.process_from_config')
-        select_process_from_config(es_instance, processes_config, "all", "/file", None)
+        select_process_from_config(processes_config, "all", "/files")
         assert pypel.main.process_from_config.call_count == 2
-        #  TODO: fix the assert_has_calls logic
-        # calls = [call(es_instance, proc, "/files", None) for proc in processes_config]
-        # print("mock_calls", pypel.main.process_from_config.mock_calls)
-        # pypel.main.process_from_config.assert_has_calls(calls)
+        calls = [mocker.call(proc, "/files") for proc in processes_config]
+        pypel.main.process_from_config.assert_has_calls(calls)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,4 +1,3 @@
-# noinspection PyPackageRequirements
 import pytest
 import pypel.processes
 import os

--- a/tests/integration/test_factory.py
+++ b/tests/integration/test_factory.py
@@ -8,27 +8,26 @@ def factory():
 
 
 class TestFactory:
-    def test_factory_defaults_when_empty_config(self, factory, es_instance):
+    def test_factory_defaults_when_empty_config(self, factory):
         expected = pypel.processes.Process()
-        obtained = factory.create_process({}, es_instance=es_instance)
+        obtained = factory.create_process({})
         assert isinstance(obtained, type(expected))
 
-    def test_factory_instantiates_non_default_transformers(self, factory, es_instance):
+    def test_factory_instantiates_non_default_transformers(self, factory):
         expected = pypel.processes.Process(transformer=pypel.transformers.Transformer)
-        obtained = factory.create_process({"Extractors": {"name": "pypel.extractors.Extractor"},
-                                           "Transformers": {"name": "pypel.transformers.Transformer"},
-                                           "Loaders": {"name": "pypel.loaders.Loader"}}, es_instance=es_instance)
+        obtained = factory.create_process({"Transformers": [{"name": "pypel.transformers.Transformer"}]})
         assert isinstance(obtained, type(expected))
 
-    def test_factory_instanciates_list_of_transformers(self, factory, es_instance):
+    def test_factory_instanciates_list_of_transformers(self, factory):
         expected = pypel.processes.Process(transformer=[pypel.transformers.ColumnStripperTransformer(),
                                                         pypel.transformers.ColumnCapitaliserTransformer()])
-        obtained = factory.create_process({"Extractors": {"name": "pypel.extractors.Extractor"},
-                                           "Transformers": [{"name": "pypel.transformers.ColumnStripperTransformer"},
-                                                            {"name": "pypel.transformers.Transformer"}],
-                                           "Loaders": {"name": "pypel.loaders.Loader"}}, es_instance=es_instance)
+        obtained = factory.create_process({"Transformers": [{"name": "pypel.transformers.ColumnStripperTransformer"},
+                                                            {"name": "pypel.transformers.Transformer"}]})
         assert isinstance(obtained, type(expected))
 
-    def test_raises_if_class_not_found(self, factory, es_instance):
+    def test_raises_if_class_not_found(self, factory):
         with pytest.raises(ValueError):
-            factory.create_process({"Extractors": {"name": "pypel.Jesus"}}, es_instance)
+            factory.create_process({"Extractor": {"name": "pypel.Jesus"},
+                                    "Transformers": [{"name": ""}],
+                                    "Loader": {"name": "",
+                                               "indice": ""}})

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -5,7 +5,7 @@ import pypel
 import os
 import datetime as dt
 import numpy
-from tests.unit.test_Loader import LoaderTest, Elasticsearch
+from tests.unit.test_Loader import LoaderTest
 
 
 class TransformerForTesting(pypel.transformers.Transformer):
@@ -218,8 +218,8 @@ def test_multiple_transformers(ep):
     assert_frame_equal(expected_df, obtained_df, check_names=True)
 
 
-def test_process_method():
+def test_process_method(es_conf, es_indice):
     path_csv = os.path.join(os.getcwd(), "tests", "fake_data", "test_init_df.csv")
-    process = pypel.processes.Process(loader=LoaderTest(Elasticsearch()))
+    process = pypel.processes.Process(loader=LoaderTest(es_conf, es_indice))
     with pytest.warns(UserWarning):
-        process.process(path_csv, "indice")
+        process.process(path_csv)

--- a/tests/unit/test_Loader.py
+++ b/tests/unit/test_Loader.py
@@ -3,15 +3,18 @@ import tempfile
 import pytest
 import pypel.loaders.Loaders as loader
 from pandas import DataFrame
-
-
-class Elasticsearch:
-    pass
+import elasticsearch
+import ssl
 
 
 class LoaderTest(loader.Loader):
-    def _bulk_into_elastic(self, actions: list, indice: str):
+    def _bulk_into_elastic(self, actions):
         pass
+
+
+@pytest.fixture
+def es_instanciating_loader(es_conf, es_indice):
+    return LoaderTest(es_conf, es_indice)
 
 
 def mock_streaming_bulk_no_error(*args, **kwargs):
@@ -27,59 +30,63 @@ def mock_streaming_bulk_some_errors(*args, **kwargs):
             yield True, {"success": True}
 
 
+def mock_ssl_context(cafile):
+    return {"name": cafile}
+
+
 class TestLoader:
-    def test_loading_export_csv(self):
+    def test_loading_export_csv(self, es_conf, es_indice):
         df = DataFrame(data=[[6, 6, 6, 6, 6],
                              [7, 7, 7, 7, 7],
                              [8, 8, 8, 8, 8],
                              [9, 9, 9, 9, 9]],
                        columns=["0", "1", "2", "3", "4"])
         with tempfile.TemporaryDirectory() as path:
-            loader_ = LoaderTest(Elasticsearch(), backup=True, path_to_export_folder=path)
-            loader_.load(df, "indice")
+            loader_ = LoaderTest(es_conf, es_indice, backup=True, path_to_export_folder=path)
+            loader_.load(df)
 
-    def test_loading_no_export(self):
+    def test_loading_no_export(self, es_conf, es_indice):
         df = DataFrame(data=[[6, 6, 6, 6, 6],
                              [7, 7, 7, 7, 7],
                              [8, 8, 8, 8, 8],
                              [9, 9, 9, 9, 9]],
                        columns=["0", "1", "2", "3", "4"])
-        loader_ = LoaderTest(Elasticsearch())
-        loader_.load(df, "indice")
+        loader_ = LoaderTest(es_conf, es_indice)
+        loader_.load(df)
 
-    def test_loading_export_named_file(self):
+    def test_loading_export_named_file(self, es_conf, es_indice):
         df = DataFrame(data=[[6, 6, 6, 6, 6],
                              [7, 7, 7, 7, 7],
                              [8, 8, 8, 8, 8],
                              [9, 9, 9, 9, 9]],
                        columns=["0", "1", "2", "3", "4"])
         with tempfile.TemporaryDirectory() as path:
-            loader_ = LoaderTest(Elasticsearch(), backup=True, path_to_export_folder=path, name_export="name")
-            loader_.load(df, "indice")
+            loader_ = LoaderTest(es_conf, es_indice, backup=True, path_to_export_folder=path, name_export="name")
+            loader_.load(df)
 
-    def test_bad_folder_crashes(self):
+    def test_bad_folder_crashes(self, es_conf, es_indice):
         with pytest.raises(ValueError):
-            loader.Loader(Elasticsearch(), path_to_export_folder="/this_folder_does_not_exist", backup=True)
+            loader.Loader(es_conf, es_indice, path_to_export_folder="/this_folder_does_not_exist", backup=True)
 
-    def test_no_folder_crashes(self):
+    def test_no_folder_crashes(self, es_conf, es_indice):
         with pytest.raises(ValueError):
-            loader.Loader(Elasticsearch(), backup=True)
+            loader.Loader(es_conf, es_indice, backup=True)
 
-    def test_good_folder(self):
-        loader.Loader(Elasticsearch(), path_to_export_folder="/", backup=True)
+    def test_good_folder(self, es_conf, es_indice):
+        loader.Loader(es_conf, es_indice, path_to_export_folder="/", backup=True)
 
-    def test_no_backup(self):
-        loader.Loader(Elasticsearch())
+    def test_no_backup(self, es_conf, es_indice):
+        loader.Loader(es_conf, es_indice)
 
-    def test_bulk_into_elastic(self, monkeypatch):
+    def test_bulk_into_elastic(self, monkeypatch, es_conf, es_indice):
         monkeypatch.setattr(loader.elasticsearch.helpers, "streaming_bulk", mock_streaming_bulk_no_error)
-        loader.Loader(Elasticsearch())._bulk_into_elastic([], "indice")
+        loader.Loader(es_conf, es_indice)._bulk_into_elastic([])
 
-    def test_bulk_into_elastic_warns_on_error(self, monkeypatch):
+    def test_bulk_into_elastic_warns_on_error(self, monkeypatch, es_conf, es_indice):
         monkeypatch.setattr(loader.elasticsearch.helpers, "streaming_bulk",
                             mock_streaming_bulk_some_errors)
         with pytest.warns(UserWarning):
-            loader.Loader(Elasticsearch())._bulk_into_elastic([], "indice")
+            loader.Loader(es_conf, es_indice)._bulk_into_elastic([])
 
 
 class TestCSVWriter:
@@ -94,3 +101,37 @@ class TestCSVWriter:
             file_name = "tmpcsv.csv"
             loader_.load(df, path + f"/{file_name}")
             assert file_name in os.listdir(path)
+
+
+class TestGetESInstance:
+    def test_no_authentication(self, monkeypatch, es_instanciating_loader):
+        def assert_es_instanciation_called_with(hosts, http_auth, use_ssl=False, scheme=None, port=8080,
+                                                ssl_context=None):
+            assert hosts == "localhost"
+            assert http_auth is None
+        monkeypatch.setattr(elasticsearch, "Elasticsearch", assert_es_instanciation_called_with)
+        es_instanciating_loader._instantiate_es({})
+
+    def test_authentication_no_cafile(self, monkeypatch, es_instanciating_loader):
+        def assert_es_instanciation_called_with(hosts, http_auth, use_ssl=False, scheme=None, port=8080,
+                                                ssl_context=None):
+            assert hosts == "localhost"
+            assert http_auth == ("user", "my_pwd")
+
+        monkeypatch.setattr(elasticsearch, "Elasticsearch", assert_es_instanciation_called_with)
+        es_instanciating_loader._instantiate_es({"user": "user", "pwd": "my_pwd"})
+
+    def test_cafile(self, monkeypatch, es_instanciating_loader):
+        def assert_es_instanciation_called_with(hosts, http_auth, use_ssl=False, scheme=None, port=8080,
+                                                ssl_context=None):
+            assert hosts == "1.12.4.2"
+            assert http_auth == ("elastic", "changeme")
+            assert use_ssl is True
+            assert scheme == "https"
+            assert port == 8080
+            assert ssl_context == {"name": "fake_cafile_content"}
+
+        monkeypatch.setattr(elasticsearch, "Elasticsearch", assert_es_instanciation_called_with)
+        monkeypatch.setattr(ssl, "create_default_context", mock_ssl_context)
+        es_instanciating_loader._instantiate_es({"user": "elastic", "pwd": "changeme", "host": "1.12.4.2", "scheme": "https", "port": 8080,
+                         "cafile": "fake_cafile_content"})

--- a/tests/unit/test_unit_process.py
+++ b/tests/unit/test_unit_process.py
@@ -6,12 +6,8 @@ from pypel.processes import Process
 from pandas import DataFrame
 
 
-class Elasticsearch:
-    pass
-
-
 class LoaderTest(Loader):
-    def load(self, dataframe, indice):
+    def load(self, dataframe):
         pass
 
 
@@ -26,8 +22,8 @@ def df():
 
 
 @pytest.fixture
-def process():
-    return Process(extractor=ExtractorTest(), transformer=Transformer(), loader=LoaderTest(Elasticsearch()))
+def process(es_conf):
+    return Process(extractor=ExtractorTest(), transformer=Transformer(), loader=LoaderTest(es_conf, "dummy"))
 
 
 class TestWarnings:
@@ -39,9 +35,9 @@ class TestWarnings:
 
     def test_instanced_loader_warns_if_addition_params_are_passed(self, process, df):
         with pytest.warns(UserWarning):
-            process.load(df, "fake", Elasticsearch(), 0)
+            process.load(df, "fake", {}, 0)
         with pytest.warns(UserWarning):
-            process.load(df, "fake", Elasticsearch(), keyword_arg=0)
+            process.load(df, "fake", {}, keyword_arg=0)
 
 
 class TestParameters:
@@ -52,17 +48,27 @@ class TestParameters:
 
 
 class TestBulk:
-    def test_bulk_crashes_if_transformer_not_instanced(self):
-        process_bad_transformer = Process(loader=Loader(Elasticsearch()))
+    def test_bulk_crashes_if_transformer_not_instanced(self, es_conf, es_indice):
+        process_bad_transformer = Process(loader=Loader(es_conf, es_indice))
         with pytest.raises(ValueError, match="Transformer not instanced"):
-            process_bad_transformer.bulk({"fake": "also_fake"})
+            process_bad_transformer.bulk([])
 
     def test_bulk_crashes_if_loader_not_instanced(self):
         process_bad_loader = Process(transformer=Transformer())
         with pytest.raises(ValueError, match="Loader not instanced"):
-            process_bad_loader.bulk({"fake": "also_fake"})
+            process_bad_loader.bulk([])
 
     def test_bulk_crashes_if_both_not_instanced(self):
         process_bad_loader = Process()
         with pytest.raises(ValueError, match="Transformer, Loader not instanced"):
-            process_bad_loader.bulk({"fake": "also_fake"})
+            process_bad_loader.bulk([])
+
+    def test_bulk(self, es_conf, es_indice, mocker):
+        mocker.patch('pypel.processes.Process.process')
+        process = Process(transformer=Transformer(), loader=Loader(es_conf, es_indice))
+        arg = ["file1", "file2", "file3"]
+        process.bulk(arg)
+        assert Process.process.call_count == 3
+        calls = [mocker.call(file) for file in arg]
+        print("mock_calls", Process.process.mock_calls)
+        Process.process.assert_has_calls(calls)

--- a/tests/unit/test_unit_process.py
+++ b/tests/unit/test_unit_process.py
@@ -70,5 +70,4 @@ class TestBulk:
         process.bulk(arg)
         assert Process.process.call_count == 3
         calls = [mocker.call(file) for file in arg]
-        print("mock_calls", Process.process.mock_calls)
         Process.process.assert_has_calls(calls)


### PR DESCRIPTION
## Description
Elasticsearch-related loaders now have responsibility for elasticsearch-related operations, as they should.

## Motivation and Context
Closes #79 
Closes #87 

## How Has This Been Tested?
regular test suite

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
